### PR TITLE
tabs replaces by 2 spaces

### DIFF
--- a/lessons_list.json
+++ b/lessons_list.json
@@ -11,7 +11,7 @@
                 "url": "https://raw.githubusercontent.com/autolab-fi/line-robot-curriculum/main/lessons/module_1/draw.md",
                 "sn": 0,
                 "description": "Introduction to the platform, listing all peripherals, describing what we will be working with, and outlining any restrictions on libraries and tag words.",
-                "template":"// Include the library for controlling the robot\n#include <lineRobot.h>\n// The setup() function runs once when the robot is powered on or reset\nvoid setup() {\n\t// Comment lines with commands you do not want to use\n\t// To comment out a line, just add \"//\" at the beginning of the line\n\trobot.turnLeftAngle(45);\n\trobot.moveForwardDistance(20);\n\trobot.turnRight();\n\trobot.moveForwardDistance(20);\n\trobot.turnRight();\n\trobot.moveForwardDistance(20);\n\trobot.turnRight();\n\trobot.moveForwardDistance(20);\n}\n\n// The loop() function runs repeatedly after setup() has finished\nvoid loop() {\n\t// No instructions for continuous execution\n}"
+                "template":"// Include the library for controlling the robot\n#include <lineRobot.h>\n// The setup() function runs once when the robot is powered on or reset\nvoid setup() {\n  // Comment lines with commands you do not want to use\n  // To comment out a line, just add \"//\" at the beginning of the line\n  robot.turnLeftAngle(45);\n  robot.moveForwardDistance(20);\n  robot.turnRight();\n  robot.moveForwardDistance(20);\n  robot.turnRight();\n  robot.moveForwardDistance(20);\n  robot.turnRight();\n  robot.moveForwardDistance(20);\n}\n\n// The loop() function runs repeatedly after setup() has finished\nvoid loop() {\n  // No instructions for continuous execution\n}"
             },
             {
                 "str_id": "test_drive",
@@ -27,7 +27,7 @@
                 "sn": 2,
                 "name": "License to drive",
                 "description": "Writing a simple program independently, similar to the previous lesson.",
-                "template": "#include <lineRobot.h>\nvoid setup() {\n\t// Write movement function here\n}\nvoid loop(){\n}"
+                "template": "#include <lineRobot.h>\nvoid setup() {\n  // Write movement function here\n}\nvoid loop(){\n}"
             }
         ]
     },
@@ -42,7 +42,7 @@
             "sn": 3,
             "name": "Short distance race",
             "description": "Using library functions to move a specific distance, both forward and backward.",
-            "template": "#include <lineRobot.h>\nvoid setup() {\n\t// Write movement functions here\n}\nvoid loop(){\n}"
+            "template": "#include <lineRobot.h>\nvoid setup() {\n  // Write movement functions here\n}\nvoid loop(){\n}"
         },
         {
             "str_id": "maneuvering",
@@ -50,7 +50,7 @@
             "sn": 4,
             "name":"Maneuvering",
             "description": "Turning right and left in place. Task: Read data from a file and write it to another.",
-            "template": "#include <lineRobot.h>\nvoid setup() {\n\t// Write functions to rotate robot here\n}\nvoid loop(){\n}"
+            "template": "#include <lineRobot.h>\nvoid setup() {\n  // Write functions to rotate robot here\n}\nvoid loop(){\n}"
         },
         {
             "str_id": "long_distance_race",
@@ -58,7 +58,7 @@
             "sn": 5,
             "name": "Fruit Ninja",
             "description": "Writing a program with a sequence of commands to move along a trajectory depicted in the diagram.",
-            "template": "#include <lineRobot.h>\nvoid setup() {\n\t// Write sequnce of movement functions here\n}\nvoid loop(){\n}"
+            "template": "#include <lineRobot.h>\nvoid setup() {\n  // Write sequnce of movement functions here\n}\nvoid loop(){\n}"
         }]
     },
     {
@@ -73,7 +73,7 @@
             "sn": 6,
             "name": "Headlights",
             "description": "Understanding how LEDs work. Task: Turning on LEDs.",
-            "template": "#include <lineRobot.h>\nvoid setup() {\n\t// Write code to tutn on led here\n}\nvoid loop(){\n}"
+            "template": "#include <lineRobot.h>\nvoid setup() {\n  // Write code to tutn on led here\n}\nvoid loop(){\n}"
         },
         {
             "str_id": "alarm",
@@ -81,7 +81,7 @@
             "sn": 7,
             "name": "Robot's alarm",
             "description": "More about the digitalWrite() and pinMode() functions. Task: Blinking LEDs.",
-            "template": "#include <lineRobot.h>\nvoid setup() {\n\t// Use the pinMode function here\n}\nvoid loop(){\n\t// Write code to turn the LED on and off here, and don't forget to add pauses \n}"
+            "template": "#include <lineRobot.h>\nvoid setup() {\n  // Use the pinMode function here\n}\nvoid loop(){\n  // Write code to turn the LED on and off here, and don't forget to add pauses \n}"
         }]
     },
     {
@@ -95,7 +95,7 @@
             "sn": 8,
             "name": "Differential drive",
             "description": "An introduction to the robot's kinematics. Task: Experiment with functions for moving the robot forward.",
-            "template": "#include <lineRobot.h>\nvoid setup() {\n\t// Write code to run and stop the motors here\n}\nvoid loop(){\n}"
+            "template": "#include <lineRobot.h>\nvoid setup() {\n  // Write code to run and stop the motors here\n}\nvoid loop(){\n}"
         },
         {
             "str_id": "move_function",
@@ -103,7 +103,7 @@
             "sn": 9,
             "name": "Movement Function",
             "description": "Writing functions in Arduino. Task: Write a function to rotate the robot.",
-            "template": "#include <lineRobot.h>\nvoid setup() {\n\t// Call your function here\n}\nvoid loop(){\n}\n // Write your function here"
+            "template": "#include <lineRobot.h>\nvoid setup() {\n  // Call your function here\n}\nvoid loop(){\n}\n // Write your function here"
         },
         {
             "str_id": "electric_motor",
@@ -111,7 +111,7 @@
             "sn": 10,
             "name": "Electric Motor",
             "description": "Basic principles of DC motors. Task: Move to a specific point on the map using only functions for controlling motors.",
-            "template": "#include <lineRobot.h>\n\n// We recommend writing a function to control the robot's movement \nvoid setup() {\n\t// Call your function here \n}\nvoid loop(){\n}\n // Write your function here"
+            "template": "#include <lineRobot.h>\n\n// We recommend writing a function to control the robot's movement \nvoid setup() {\n  // Call your function here \n}\nvoid loop(){\n}\n // Write your function here"
         }]
     }
 ]


### PR DESCRIPTION
# Description

The changes are already in production and can be seen on ondroid.org.

I replaced the tab symbol `\t` with 2 spaces, as is standard in the Arduino IDE. However, I'm not sure if this is the best decision because, on the dashboard page's code editor, a tab equals 4 spaces. It might be more logical to adjust the number of spaces in the code editor on the frontend instead.

![image](https://github.com/user-attachments/assets/55c30ab5-36a5-4110-ba64-b1dc08aad189)


closes #26